### PR TITLE
feat: remove site-toolbar and blog posts sidebar widget

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -98,7 +98,7 @@
         {% include "extra_js.html" %}
         <script src="{{ static('common.js') }}"></script>
         <script src="{{ static('event.js') }}"></script>
-        <script src="{{ static('site-toolbar.js') }}"></script>
+
         <script>
             moment.locale('{{ LANGUAGE_CODE }}');
             $(function () {
@@ -395,7 +395,7 @@
         </span>
     </footer>
 
-    {% include "site-toolbar.html" %}
+
 </div>
 </body>
 </html>

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -15,18 +15,7 @@
         padding: 0;
     }
 
-    .blog-posts {
-        list-style-type: none;
-        padding: 0;
-        margin: 0;
-    }
-    .blog-posts li {
-        padding: 8px 0;
-        border-bottom: 1px solid #eee;
-    }
-    .blog-posts li:last-child {
-        border-bottom: none;
-    }
+
 </style>
 {% endblock %}
 
@@ -36,55 +25,7 @@
     window.point_end = {{ point_end }};
     window.point_values = {{ point_values | json | safe }};
 
-    document.addEventListener('DOMContentLoaded', function() {
-        fetch('https://behitek.com/beli5/blog/archive/')
-            .then(response => response.text())
-            .then(html => {
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(html, 'text/html');
-                
-                // Find all blog post links in the archive page
-                const links = doc.querySelectorAll('a[href*="/beli5/blog/"]');
-                const posts = [];
-                
-                links.forEach(link => {
-                    const href = link.getAttribute('href');
-                    const text = link.textContent.trim();
-                    
-                    // Skip if it's not a blog post link or if it's a duplicate
-                    if (href && href.includes('/beli5/blog/') && 
-                        !href.endsWith('/blog') && !href.endsWith('/blog/') &&
-                        text && text.length > 0 && 
-                        !posts.some(post => post.link === href)) {
-                        
-                        // Extract title (remove date prefix if present)
-                        let title = text.replace(/^\d+\s+tháng\s+\d+\s*-\s*/, '');
-                        
-                        posts.push({
-                            title: title,
-                            link: href.startsWith('http') ? href : `https://behitek.com${href}`
-                        });
-                    }
-                });
-                
-                // Take last 5 posts (most recent)
-                const recentPosts = posts.slice(-5);
-                
-                const blogList = document.getElementById('blog-posts-list');
-                if (recentPosts.length > 0) {
-                    blogList.innerHTML = recentPosts.map(post => 
-                        `<li><a href="${post.link}" target="_blank">${post.title}</a></li>`
-                    ).join('');
-                } else {
-                    blogList.innerHTML = '<li>{{ _('No blog posts found') }}</li>';
-                }
-            })
-            .catch(error => {
-                const blogList = document.getElementById('blog-posts-list');
-                blogList.innerHTML = '<li>{{ _('Failed to load blog posts') }}</li>';
-                console.error('Error fetching blog posts:', error);
-            });
-    });
+
 </script>
 {% compress js %}
 <script src="{{ static('libs/nouislider.min.js') }}" type="text/javascript"></script>
@@ -208,14 +149,7 @@
                 </div>
             </div>
             {% endif %}
-            <div class="sidebox">
-                <h3>{{ _("Blog Posts") }} <i class="fa fa-rss"></i></h3>
-                <div class="sidebox-content">
-                    <ul id="blog-posts-list" class="blog-posts">
-                        <li>{{ _("Loading...") }}</li>
-                    </ul>
-                </div>
-            </div>
+
         </div>
     </div>
     <div id="content-left" class="problems h-scrollable-table">


### PR DESCRIPTION
## Summary
- Remove `#site-toolbar` widget site-wide (`site-toolbar.js` script and `site-toolbar.html` include removed from `base.html`)
- Remove Blog Posts sidebox from the problem list right sidebar, including its CSS styles and the `fetch()` JS block that loaded posts from behitek.com

## Test plan
- [ ] Visit `/problems/` — Blog Posts sidebox should be gone from the right sidebar
- [ ] Verify no floating site-toolbar appears on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)