### PR TITLE
feat: remove blog posts sidebar from submission list

### DIFF
--- a/templates/submission/list.html
+++ b/templates/submission/list.html
@@ -27,58 +27,6 @@
     </script>
 
     {% compress js %}
-        <script type="text/javascript">
-            document.addEventListener('DOMContentLoaded', function() {
-                fetch('https://behitek.com/beli5/blog/archive/')
-                    .then(response => response.text())
-                    .then(html => {
-                        const parser = new DOMParser();
-                        const doc = parser.parseFromString(html, 'text/html');
-                        
-                        // Find all blog post links in the archive page
-                        const links = doc.querySelectorAll('a[href*="/beli5/blog/"]');
-                        const posts = [];
-                        
-                        links.forEach(link => {
-                            const href = link.getAttribute('href');
-                            const text = link.textContent.trim();
-                            
-                            // Skip if it's not a blog post link or if it's a duplicate
-                            if (href && href.includes('/beli5/blog/') && 
-                                !href.endsWith('/blog') && !href.endsWith('/blog/') &&
-                                text && text.length > 0 && 
-                                !posts.some(post => post.link === href)) {
-                                
-                                // Extract title (remove date prefix if present)
-                                let title = text.replace(/^\d+\s+tháng\s+\d+\s*-\s*/, '');
-                                
-                                posts.push({
-                                    title: title,
-                                    link: href.startsWith('http') ? href : `https://behitek.com${href}`
-                                });
-                            }
-                        });
-                        
-                        // Take last 5 posts (most recent)
-                        const recentPosts = posts.slice(-5);
-                        
-                        const blogList = document.getElementById('blog-posts-list');
-                        if (recentPosts.length > 0) {
-                            blogList.innerHTML = recentPosts.map(post => 
-                                `<li><a href="${post.link}" target="_blank">${post.title}</a></li>`
-                            ).join('');
-                        } else {
-                            blogList.innerHTML = '<li>{{ _('No blog posts found') }}</li>';
-                        }
-                    })
-                    .catch(error => {
-                        const blogList = document.getElementById('blog-posts-list');
-                        blogList.innerHTML = '<li>{{ _('Failed to load blog posts') }}</li>';
-                        console.error('Error fetching blog posts:', error);
-                    });
-            });
-        </script>
-
         {% if request.user.is_authenticated and perms.judge.rejudge_submission %}
             <script type="text/javascript">
                 window.rejudge_submission = function (id, e) {
@@ -338,18 +286,6 @@
     {% endif %}
 
     <style>
-        .blog-posts {
-            list-style-type: none;
-            padding: 0;
-            margin: 0;
-        }
-        .blog-posts li {
-            padding: 8px 0;
-            border-bottom: 1px solid #eee;
-        }
-        .blog-posts li:last-child {
-            border-bottom: none;
-        }
         .total {
             text-align: center;
             margin-bottom: 0.5em;
@@ -424,14 +360,6 @@
                                 {{ _('Total:') }} <span id="total-submission-count"></span>
                             </div>
                         </div>
-                    </div>
-                </div>
-                <div class="sidebox">
-                    <h3>{{ _('Blog Posts') }} <i class="fa fa-rss"></i></h3>
-                    <div class="sidebox-content">
-                        <ul id="blog-posts-list" class="blog-posts">
-                            <li>{{ _('Loading...') }}</li>
-                        </ul>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- Remove the Blog Posts sidebox from the submission list right sidebar
- Remove the JS fetch block that loaded posts from `behitek.com`
- Remove the `.blog-posts` CSS styles

## Test plan

- [ ] Visit the submission list page and confirm no Blog Posts widget appears in the right sidebar
- [ ] Confirm the Filter submissions and Statistics sections still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)