### PR TITLE
feat: set testcase visibility to always visible

### DIFF
--- a/judge/migrations/0218_set_testcase_visibility_always.py
+++ b/judge/migrations/0218_set_testcase_visibility_always.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0217_set_testcase_visibility_default_out_contest'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='problem',
+            name='testcase_visibility_mode',
+            field=models.CharField(
+                choices=[
+                    ('O', 'Visible for authors'),
+                    ('C', 'Visible if user is not in a contest'),
+                    ('A', 'Always visible'),
+                ],
+                default='A',
+                max_length=1,
+                verbose_name='Testcase visibility',
+            ),
+        ),
+        migrations.RunSQL(
+            sql="UPDATE judge_problem SET testcase_visibility_mode = 'A'",
+            reverse_sql="UPDATE judge_problem SET testcase_visibility_mode = 'C'",
+        ),
+    ]

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -203,7 +203,7 @@ class Problem(models.Model):
                                                          default=SubmissionSourceAccess.FOLLOW,
                                                          choices=SUBMISSION_SOURCE_ACCESS)
     testcase_visibility_mode = models.CharField(verbose_name=_('Testcase visibility'), max_length=1,
-                                                default=ProblemTestcaseAccess.OUT_CONTEST,
+                                                default=ProblemTestcaseAccess.ALWAYS,
                                                 choices=PROBLEM_TESTCASE_ACCESS)
 
     testcase_result_visibility_mode = models.CharField(verbose_name=_('Testcase result visibility'), max_length=1,


### PR DESCRIPTION
Change testcase visibility default from OUT_CONTEST to ALWAYS, and migrate all existing problems (5297) to always visible.

- Update `testcase_visibility_mode` default to `'A'` (Always visible)
- Migration 0218 bulk-updates all existing problems to `'A'`